### PR TITLE
refactor(device-identity) PR2/3: runtime device_id-first

### DIFF
--- a/apps/gui/src/commands.rs
+++ b/apps/gui/src/commands.rs
@@ -3,7 +3,7 @@ use tauri::State;
 use corsair_common::config::{AppConfig, RgbConfig};
 use corsair_fancontrol::control_loop;
 
-use crate::dto::{DeviceTree, SystemSnapshot};
+use crate::dto::{DeviceTree, ManualDutyResult, SystemSnapshot};
 use crate::state::{AppState, HwCommand};
 
 #[tauri::command]
@@ -67,6 +67,14 @@ pub async fn apply_preset(
         .map_err(|_| "Hardware thread dropped".to_string())?
 }
 
+/// Legacy V1 duty command — still used by the unmigrated Svelte frontend.
+/// Kept for one release so we don't break the UI in the middle of the
+/// device-identity refactor; PR3 migrates callers to
+/// [`set_manual_duty_by_device_id`] and a future release deletes this.
+#[deprecated(
+    since = "0.1.2",
+    note = "Use set_manual_duty_by_device_id; channel-based addressing is fragile across topology changes."
+)]
 #[tauri::command]
 pub async fn set_manual_duty(
     state: State<'_, AppState>,
@@ -84,6 +92,58 @@ pub async fn set_manual_duty(
             hub_serial,
             channels,
             duty,
+            reply: tx,
+        })
+        .map_err(|_| "Hardware thread unavailable".to_string())?;
+    rx.await
+        .map_err(|_| "Hardware thread dropped".to_string())?
+}
+
+/// V2 duty command: caller supplies a list of `device_id` strings. The
+/// hardware thread resolves each to its current (hub_serial, channel)
+/// pair, buckets by hub, and issues one `set_speeds` per hub. The
+/// returned [`ManualDutyResult`] distinguishes applied vs unresolved ids
+/// so the UI can surface orphans without hiding partial success as a
+/// blanket error.
+#[tauri::command]
+pub async fn set_manual_duty_by_device_id(
+    state: State<'_, AppState>,
+    device_ids: Vec<String>,
+    duty: u8,
+) -> Result<ManualDutyResult, String> {
+    if duty > 100 {
+        return Err("duty must be 0-100".into());
+    }
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    state
+        .hw_sender
+        .send(HwCommand::SetManualDutyByDeviceId {
+            device_ids,
+            duty,
+            reply: tx,
+        })
+        .map_err(|_| "Hardware thread unavailable".to_string())?;
+    rx.await
+        .map_err(|_| "Hardware thread dropped".to_string())?
+}
+
+/// Rename (or clear the custom name of) a specific device by its stable
+/// device_id. Empty `name` clears the entry, reverting the UI to the
+/// system-generated fallback label. Persisted atomically via the shared
+/// config write path; the control loop is notified live so a subsequent
+/// get_config returns the new name without a round-trip through disk.
+#[tauri::command]
+pub async fn rename_device(
+    state: State<'_, AppState>,
+    device_id: String,
+    name: String,
+) -> Result<(), String> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    state
+        .hw_sender
+        .send(HwCommand::RenameDevice {
+            device_id,
+            name,
             reply: tx,
         })
         .map_err(|_| "Hardware thread unavailable".to_string())?;

--- a/apps/gui/src/dto.rs
+++ b/apps/gui/src/dto.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 
+use corsair_common::identity::DeviceRegistry;
 use corsair_fancontrol::CycleResult;
 use corsair_hid::{DeviceGroup, FanSpeed, HubInfo, PsuStatus};
 use corsair_rgb::RgbFrame;
@@ -99,26 +100,34 @@ pub struct PsuDeviceInfo {
 
 /// Compact RGB frame for IPC — emitted as Tauri event at 30 FPS.
 ///
-/// `device_id` is the stable identity for this device; `hub_serial` + `channel`
-/// are runtime location metadata (kept during the V1→V2 transition so the
-/// preview renderer and diagnostics keep working without UI changes). Frontend
-/// code landing in a later step will key on `device_id` only.
+/// `device_id` is the stable identity. `hub_serial` + `channel` are the
+/// currently-resolved runtime location, included for the duration of the
+/// V1→V2 UI transition: the Svelte preview still keys by channel (PR3 will
+/// migrate it). The backend resolves `(hub_serial, channel)` from the
+/// registry at emit time so the DTO is always self-consistent — if the
+/// device can't be resolved now, the location fields are empty.
 #[derive(Debug, Clone, Serialize)]
 pub struct RgbFrameDto {
     pub hub_serial: String,
     pub channel: u8,
-    /// Stable device identity. Empty string when the frame originated from a
-    /// zone whose device target has not yet been paired with an enumerated
-    /// device (intermediate transition state during refactor).
+    /// Stable device identity. Always populated by the backend post-Step 5.
     pub device_id: String,
     pub leds: Vec<[u8; 3]>,
 }
 
 impl RgbFrameDto {
-    pub fn from_frame(frame: &RgbFrame) -> Self {
+    /// Build a DTO from a renderer frame, resolving `(hub_serial, channel)`
+    /// from the current registry. If the device_id is not in the registry
+    /// (orphan — e.g. fan unplugged between frame render and emit), we emit
+    /// empty location strings. The frontend treats empty fields as "unknown
+    /// location" and continues to render by device_id once PR3 lands.
+    pub fn from_frame(frame: &RgbFrame, registry: &DeviceRegistry) -> Self {
+        let (hub_serial, channel) = registry
+            .channel_for(&frame.device_id)
+            .unwrap_or_else(|| (String::new(), 0));
         Self {
-            hub_serial: frame.hub_serial.clone(),
-            channel: frame.channel,
+            hub_serial,
+            channel,
             device_id: frame.device_id.clone(),
             leds: frame.leds.iter().map(|c| [c.r, c.g, c.b]).collect(),
         }

--- a/apps/gui/src/dto.rs
+++ b/apps/gui/src/dto.rs
@@ -76,6 +76,19 @@ pub struct DeviceTree {
     pub psu: Option<PsuDeviceInfo>,
 }
 
+/// Result of `set_manual_duty_by_device_id`. The UI uses `unresolved` to
+/// show which fans were not driven (e.g. because the device is currently
+/// unplugged) without hiding the partial-success case as a blanket error.
+#[derive(Debug, Clone, Serialize)]
+pub struct ManualDutyResult {
+    /// Device ids that were resolved and whose hub was commanded.
+    pub applied: Vec<String>,
+    /// Device ids that did not resolve via the current registry. Caller
+    /// surfaces these as a warning — the devices are not enumerated at
+    /// this moment (unplugged, moved, or renamed-out).
+    pub unresolved: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct HubSnapshot {
     pub serial: String,

--- a/apps/gui/src/hardware_thread.rs
+++ b/apps/gui/src/hardware_thread.rs
@@ -192,6 +192,31 @@ fn run_loop(
                             .map_err(|e| format!("Failed to set duty: {}", e));
                         let _ = reply.send(result);
                     }
+                    HwCommand::SetManualDutyByDeviceId {
+                        device_ids,
+                        duty,
+                        reply,
+                    } => {
+                        let result = apply_manual_duty_by_device_id(
+                            &control_loop,
+                            &device_ids,
+                            duty,
+                        );
+                        let _ = reply.send(result);
+                    }
+                    HwCommand::RenameDevice {
+                        device_id,
+                        name,
+                        reply,
+                    } => {
+                        let result = apply_rename_device(
+                            &mut config,
+                            &mut control_loop,
+                            &device_id,
+                            &name,
+                        );
+                        let _ = reply.send(result);
+                    }
                     HwCommand::SetRgbConfig {
                         config: rgb_config,
                         reply,
@@ -472,6 +497,12 @@ fn run_degraded(rx: mpsc::Receiver<HwCommand>) {
             Ok(HwCommand::SetManualDuty { reply, .. }) => {
                 let _ = reply.send(Err("Hardware unavailable".into()));
             }
+            Ok(HwCommand::SetManualDutyByDeviceId { reply, .. }) => {
+                let _ = reply.send(Err("Hardware unavailable".into()));
+            }
+            Ok(HwCommand::RenameDevice { reply, .. }) => {
+                let _ = reply.send(Err("Hardware unavailable".into()));
+            }
             Ok(HwCommand::SetRgbConfig { reply, .. }) => {
                 let _ = reply.send(Err("Hardware unavailable".into()));
             }
@@ -508,6 +539,12 @@ fn run_discovery_only(
                 let _ = reply.send(Err("Control loop not running".into()));
             }
             Ok(HwCommand::SetManualDuty { reply, .. }) => {
+                let _ = reply.send(Err("Control loop not running".into()));
+            }
+            Ok(HwCommand::SetManualDutyByDeviceId { reply, .. }) => {
+                let _ = reply.send(Err("Control loop not running".into()));
+            }
+            Ok(HwCommand::RenameDevice { reply, .. }) => {
                 let _ = reply.send(Err("Control loop not running".into()));
             }
             Ok(HwCommand::SetRgbConfig { reply, .. }) => {
@@ -851,6 +888,116 @@ fn apply_rgb_config(
     renderer.update_config(&zones, config.rgb.brightness as f32 / 100.0);
 }
 
+/// Resolve each device_id via the control loop's registry, bucket by hub,
+/// and issue one `set_speeds` per hub. Returns a structured result listing
+/// which ids were applied vs unresolved so the UI can surface partial-
+/// success cases (e.g. a fan was unplugged between enumeration and the
+/// user's click).
+///
+/// ## Why we group per hub
+///
+/// `ControlLoop::set_manual_duty(hub, channels, duty)` takes a slice of
+/// channels per hub — one hub call per group. A V2 fan selection can
+/// span multiple hubs, so we bucket before issuing any hub calls and
+/// treat the per-hub call as atomic (either all its channels are
+/// commanded or none — a mid-hub failure stops further channels on
+/// that hub but doesn't roll back earlier hubs). Errors from a
+/// per-hub call are propagated as a String error so the command
+/// Result captures them.
+fn apply_manual_duty_by_device_id(
+    control_loop: &ControlLoop,
+    device_ids: &[String],
+    duty: u8,
+) -> Result<crate::dto::ManualDutyResult, String> {
+    if duty > 100 {
+        return Err("duty must be 0-100".into());
+    }
+    let registry = control_loop.registry();
+    let mut per_hub: std::collections::HashMap<String, Vec<u8>> =
+        std::collections::HashMap::new();
+    let mut applied: Vec<String> = Vec::new();
+    let mut unresolved: Vec<String> = Vec::new();
+    for id in device_ids {
+        match registry.channel_for(id) {
+            Some((hub, ch)) => {
+                per_hub.entry(hub).or_default().push(ch);
+                applied.push(id.clone());
+            }
+            None => unresolved.push(id.clone()),
+        }
+    }
+    for (hub, channels) in &per_hub {
+        control_loop
+            .set_manual_duty(hub, channels, duty)
+            .map_err(|e| format!("Failed to set duty on hub '{}': {}", hub, e))?;
+    }
+    Ok(crate::dto::ManualDutyResult {
+        applied,
+        unresolved,
+    })
+}
+
+/// Mutate `config.devices` to set a friendly name for `device_id`:
+/// - An empty `name` clears the device entry (revert to system default).
+/// - A non-empty `name` upserts — existing entry's `name` is updated;
+///   absent entry gets inserted. `led_count` on an existing entry is
+///   preserved.
+///
+/// Pure mutation. The caller is responsible for persisting and for
+/// informing the control loop via `update_config`. Exposed as
+/// `pub(crate)` for unit testing without Tauri state.
+pub(crate) fn rename_device_in_config(
+    config: &mut AppConfig,
+    device_id: &str,
+    name: &str,
+) {
+    // NB: writing to `config.devices` is safe even on a V1 config —
+    // `AppConfig.devices: Vec<v2::DeviceEntry>` has `#[serde(default)]`
+    // and serializes with `#[serde(skip_serializing_if = "Option::is_none")]`
+    // on optional fields, so a V1 round-trip with one new device entry
+    // produces a file that still parses as V1 and also as V2. We do NOT
+    // bump `schema_version` here — renaming is orthogonal to schema
+    // version; Step 10 (migration wiring) owns that transition.
+    if name.is_empty() {
+        config.devices.retain(|d| d.device_id != device_id);
+        return;
+    }
+    if let Some(existing) = config.devices.iter_mut().find(|d| d.device_id == device_id) {
+        existing.name = Some(name.to_string());
+    } else {
+        config
+            .devices
+            .push(corsair_common::config::v2::DeviceEntry {
+                device_id: device_id.to_string(),
+                name: Some(name.to_string()),
+                led_count: None,
+            });
+    }
+}
+
+/// Handle `HwCommand::RenameDevice`: mutate config, persist, notify
+/// control loop. Returns a String error if persistence fails; the
+/// in-memory mutation is best-effort applied even if write fails, so the
+/// UI stays consistent with what it just committed to.
+fn apply_rename_device(
+    config: &mut AppConfig,
+    control_loop: &mut ControlLoop,
+    device_id: &str,
+    name: &str,
+) -> Result<(), String> {
+    rename_device_in_config(config, device_id, name);
+    if let Err(e) = save_config_to_disk(config) {
+        return Err(format!("Failed to persist renamed device: {}", e));
+    }
+    // Apply live so a subsequent get_config returns the new name without
+    // a round-trip through disk. update_config re-runs its device-entry
+    // pass; since we only changed `name`, no led_count rewrite happens.
+    if let Err(e) = control_loop.update_config(config.clone()) {
+        return Err(format!("Failed to apply rename to control loop: {}", e));
+    }
+    Ok(())
+}
+
 fn save_config_to_disk(config: &AppConfig) -> Result<()> {
     let toml_str = toml::to_string_pretty(config)
         .map_err(|e| anyhow::anyhow!("Failed to serialize config: {}", e))?;
@@ -862,4 +1009,135 @@ fn save_config_to_disk(config: &AppConfig) -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to write {}: {}", config_path.display(), e))?;
     info!("Config saved to {}", config_path.display());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use corsair_common::config::v2::DeviceEntry;
+    use corsair_common::config::{FanMode, GeneralConfig, SCHEMA_VERSION_V1};
+
+    /// Baseline V1 config used by rename tests — no schema_version bump
+    /// happens on rename so we pin the starting state explicitly.
+    fn empty_v1_config() -> AppConfig {
+        AppConfig {
+            schema_version: SCHEMA_VERSION_V1,
+            general: GeneralConfig {
+                poll_interval_ms: 1000,
+                log_level: "info".to_string(),
+                lhm_exe_path: None,
+            },
+            fan_groups: Vec::new(),
+            rgb: Default::default(),
+            device_overrides: Vec::new(),
+            devices: Vec::new(),
+        }
+    }
+
+    /// Renaming a device that has no existing entry inserts a new one
+    /// with `name` set and `led_count = None` (preserves the invariant
+    /// that renaming is orthogonal to LED-count overrides). Schema
+    /// version is left untouched — the plan says rename is orthogonal
+    /// to schema version.
+    #[test]
+    fn rename_device_inserts_new_entry() {
+        let mut cfg = empty_v1_config();
+        rename_device_in_config(&mut cfg, "ID_A1", "Top Front Left");
+        assert_eq!(cfg.devices.len(), 1);
+        assert_eq!(
+            cfg.devices[0],
+            DeviceEntry {
+                device_id: "ID_A1".to_string(),
+                name: Some("Top Front Left".to_string()),
+                led_count: None,
+            }
+        );
+        // Schema version NOT bumped by rename — orthogonal concerns.
+        assert_eq!(cfg.schema_version, SCHEMA_VERSION_V1);
+    }
+
+    /// Renaming an existing entry updates its `name` while preserving
+    /// any `led_count` override that was already set for that device.
+    #[test]
+    fn rename_device_preserves_led_count() {
+        let mut cfg = empty_v1_config();
+        cfg.devices.push(DeviceEntry {
+            device_id: "ID_A1".to_string(),
+            name: Some("Old Name".to_string()),
+            led_count: Some(30),
+        });
+
+        rename_device_in_config(&mut cfg, "ID_A1", "New Name");
+
+        assert_eq!(cfg.devices.len(), 1);
+        assert_eq!(cfg.devices[0].name.as_deref(), Some("New Name"));
+        assert_eq!(
+            cfg.devices[0].led_count,
+            Some(30),
+            "led_count override must survive a rename"
+        );
+    }
+
+    /// An empty `name` removes the device entry entirely. If the entry
+    /// also carried an led_count, the user loses it — that's the
+    /// documented contract (empty name = "revert to defaults, drop
+    /// everything"). If that's not what the user wanted, they'd keep a
+    /// placeholder name or edit the override separately.
+    #[test]
+    fn rename_device_empty_name_removes_entry() {
+        let mut cfg = empty_v1_config();
+        cfg.devices.push(DeviceEntry {
+            device_id: "ID_A1".to_string(),
+            name: Some("Old Name".to_string()),
+            led_count: Some(42),
+        });
+        cfg.devices.push(DeviceEntry {
+            device_id: "ID_B1".to_string(),
+            name: Some("Keep Me".to_string()),
+            led_count: None,
+        });
+
+        rename_device_in_config(&mut cfg, "ID_A1", "");
+
+        assert_eq!(cfg.devices.len(), 1);
+        assert_eq!(cfg.devices[0].device_id, "ID_B1");
+    }
+
+    /// Renaming a non-existent device_id while asking for an empty name
+    /// is a no-op (don't insert an entry just to immediately clear it).
+    #[test]
+    fn rename_device_empty_name_on_missing_is_noop() {
+        let mut cfg = empty_v1_config();
+        rename_device_in_config(&mut cfg, "ID_NONE", "");
+        assert!(cfg.devices.is_empty());
+    }
+
+    /// V1-shaped config round-trips cleanly with a newly-added V2
+    /// device entry. The serde skip_serializing_if attributes on
+    /// DeviceEntry.name / led_count keep the output compact and backwards
+    /// parseable.
+    #[test]
+    fn rename_device_roundtrips_through_toml_on_v1_config() {
+        let mut cfg = empty_v1_config();
+        // Add a V1 fan group so the serialized form is realistic.
+        cfg.fan_groups.push(corsair_common::config::FanGroupConfig {
+            name: "g1".to_string(),
+            channels: vec![1, 2],
+            hub_serial: Some("HUB_A".to_string()),
+            device_ids: Vec::new(),
+            mode: FanMode::Fixed { duty_percent: 50.0 },
+        });
+
+        rename_device_in_config(&mut cfg, "ID_A1", "Top Front");
+
+        let toml_str = toml::to_string(&cfg).expect("serialize");
+        let reparsed: AppConfig = toml::from_str(&toml_str).expect("reparse");
+
+        assert_eq!(reparsed.schema_version, SCHEMA_VERSION_V1);
+        assert_eq!(reparsed.devices.len(), 1);
+        assert_eq!(reparsed.devices[0].device_id, "ID_A1");
+        assert_eq!(reparsed.devices[0].name.as_deref(), Some("Top Front"));
+        assert_eq!(reparsed.fan_groups.len(), 1);
+        assert_eq!(reparsed.fan_groups[0].channels, vec![1, 2]);
+    }
 }

--- a/apps/gui/src/hardware_thread.rs
+++ b/apps/gui/src/hardware_thread.rs
@@ -6,8 +6,9 @@ use tauri::Emitter;
 use tracing::{error, info, warn};
 
 use corsair_common::config::AppConfig;
+use corsair_common::identity::DeviceRegistry;
 use corsair_common::CorsairDevice;
-use corsair_fancontrol::control_loop::{self, ControlLoop, RgbFrameRef};
+use corsair_fancontrol::control_loop::{self, ControlLoop};
 use corsair_hid::{port_power_factor, CorsairPsu, DeviceScanner, IcueLinkHub, LinkDeviceType};
 use corsair_rgb::effect::EffectContext;
 use corsair_rgb::layout::LedLayout;
@@ -89,7 +90,12 @@ fn run_loop(
     let mut last_rgb_tick = Instant::now();
     let mut last_temp: Option<f64> = None;
     let mut last_temp_time: Option<Instant> = None;
-    apply_rgb_config(&mut rgb_renderer, &config, &control_loop.device_type_map());
+    apply_rgb_config(
+        &mut rgb_renderer,
+        &config,
+        &control_loop.device_type_map(),
+        control_loop.registry(),
+    );
 
     info!(
         interval_ms = config.general.poll_interval_ms,
@@ -197,7 +203,12 @@ fn run_loop(
                         } else {
                             33
                         });
-                        apply_rgb_config(&mut rgb_renderer, &config, &control_loop.device_type_map());
+                        apply_rgb_config(
+                            &mut rgb_renderer,
+                            &config,
+                            &control_loop.device_type_map(),
+                            control_loop.registry(),
+                        );
                         if let Err(e) = save_config_to_disk(&config) {
                             warn!("Failed to save RGB config: {}", e);
                         }
@@ -362,8 +373,14 @@ fn run_loop(
             };
 
             let frames = rgb_renderer.tick(&effect_ctx);
-            let frame_dtos: Vec<RgbFrameDto> =
-                frames.iter().map(RgbFrameDto::from_frame).collect();
+            // Resolve (hub_serial, channel) via the current registry so the
+            // DTO carries a self-consistent snapshot for the preview UI
+            // during the V1→V2 transition.
+            let registry_snapshot = control_loop.registry();
+            let frame_dtos: Vec<RgbFrameDto> = frames
+                .iter()
+                .map(|f| RgbFrameDto::from_frame(f, registry_snapshot))
+                .collect();
             let _ = app.emit("rgb-frame", &frame_dtos);
 
             // Send to hardware if enabled
@@ -395,19 +412,14 @@ fn run_loop(
                     })
                     .collect();
 
-                let frame_refs: Vec<RgbFrameRef> = frames
+                // Post-Step-5: send_rgb_frames takes (device_id, leds) only.
+                // The renderer already keys frames by device_id; the control
+                // loop resolves to (hub_serial, channel) via the registry
+                // immediately before the wire write.
+                let frame_refs: Vec<(String, &[[u8; 3]])> = frames
                     .iter()
                     .zip(hw_leds.iter())
-                    .map(|(f, leds)| RgbFrameRef {
-                        hub_serial: &f.hub_serial,
-                        channel: f.channel,
-                        // device_id passes through from the renderer;
-                        // non-empty when the zone was populated from a V2
-                        // config, empty for V1. send_rgb_frames handles
-                        // both cases.
-                        device_id: &f.device_id,
-                        leds,
-                    })
+                    .map(|(f, leds)| (f.device_id.clone(), leds.as_slice()))
                     .collect();
 
                 let sent = control_loop.send_rgb_frames(&frame_refs);
@@ -722,12 +734,33 @@ fn apply_preset(
 }
 
 /// Convert the RGB config into renderer zone configs and apply.
-/// Uses the device type map to assign correct LED layouts (fan ring vs linear strip).
+///
+/// Post-Step-5 (PR2): every `DeviceConfig` carries a non-empty `device_id`.
+/// Source of truth depends on the config schema:
+///   - **V2** (`config.is_v2()`): `RgbDeviceRef.device_id` is authoritative —
+///     we use it directly. Layout resolution then tries to find the device
+///     by device_id in the registry; if the device isn't currently
+///     enumerated we emit a warning and skip it (orphan — the config
+///     reference is preserved, but this tick's renderer won't include it).
+///   - **V1** (`!config.is_v2()`): the `RgbDeviceRef` carries
+///     `(hub_serial, channel)` only. We resolve that pair to a device_id
+///     via the live registry. If the lookup fails (device not enumerated
+///     this boot), we warn and skip — consistent with the V2 path above.
+///
+/// Skipping is the correct behavior for unresolved references: the
+/// renderer's Step 5 invariant is "every DeviceTarget has a device_id", and
+/// letting an empty-device_id DeviceTarget through would trip the `expect`
+/// in `RgbRenderer::tick`. The user-visible effect of skipping is the same
+/// as the pre-refactor "orphan" behavior in the control loop — that zone
+/// just doesn't drive the missing fan this tick, and rejoins
+/// automatically when the device reappears and the registry is rebuilt.
 fn apply_rgb_config(
     renderer: &mut RgbRenderer,
     config: &AppConfig,
     device_types: &std::collections::HashMap<(String, u8), (LinkDeviceType, u16)>,
+    registry: &DeviceRegistry,
 ) {
+    let is_v2 = config.is_v2();
     let zones: Vec<ZoneConfig> = config
         .rgb
         .zones
@@ -736,8 +769,51 @@ fn apply_rgb_config(
             let devices = z
                 .devices
                 .iter()
-                .map(|d| {
-                    let layout = match device_types.get(&(d.hub_serial.clone(), d.channel)) {
+                .filter_map(|d| {
+                    // Resolve device_id: V2 uses the config field directly,
+                    // V1 resolves (hub_serial, channel) via the registry.
+                    let device_id = if is_v2 && !d.device_id.is_empty() {
+                        d.device_id.clone()
+                    } else {
+                        match registry.device_id_at(&d.hub_serial, d.channel) {
+                            Some(id) => id.to_string(),
+                            None => {
+                                warn!(
+                                    hub_serial = d.hub_serial.as_str(),
+                                    channel = d.channel,
+                                    zone = z.name.as_str(),
+                                    "RGB zone references device not currently enumerated — \
+                                     skipping in renderer (will rejoin on next enumeration)"
+                                );
+                                return None;
+                            }
+                        }
+                    };
+
+                    // Layout: prefer registry-resolved (hub, channel) for V2,
+                    // or the V1 config's literal (hub, channel). Either way we
+                    // look up the device_type_map to pick the right LED layout.
+                    let (lookup_hub, lookup_ch) = if is_v2 {
+                        match registry.channel_for(&device_id) {
+                            Some(hc) => hc,
+                            None => {
+                                // V2 reference to a device not currently
+                                // enumerated — skip (same orphan semantics
+                                // as above, different source path).
+                                warn!(
+                                    device_id = device_id.as_str(),
+                                    zone = z.name.as_str(),
+                                    "V2 RGB zone references device_id not currently \
+                                     enumerated — skipping in renderer"
+                                );
+                                return None;
+                            }
+                        }
+                    } else {
+                        (d.hub_serial.clone(), d.channel)
+                    };
+
+                    let layout = match device_types.get(&(lookup_hub, lookup_ch)) {
                         Some((LinkDeviceType::LinkAdapter | LinkDeviceType::LsStrip, led_count)) => {
                             LedLayout::LinearStrip { led_count: *led_count }
                         }
@@ -746,14 +822,8 @@ fn apply_rgb_config(
                         }
                         _ => LedLayout::qx_fan(), // safe fallback
                     };
-                    DeviceConfig {
-                        hub_serial: d.hub_serial.clone(),
-                        channel: d.channel,
-                        // Step 1 transition: V1 config has no device_id.
-                        // PR2 will populate this from the registry lookup.
-                        device_id: None,
-                        layout,
-                    }
+
+                    Some(DeviceConfig { device_id, layout })
                 })
                 .collect();
 

--- a/apps/gui/src/lib.rs
+++ b/apps/gui/src/lib.rs
@@ -130,7 +130,10 @@ pub fn run() {
             commands::get_config,
             commands::save_config,
             commands::apply_preset,
+            #[allow(deprecated)]
             commands::set_manual_duty,
+            commands::set_manual_duty_by_device_id,
+            commands::rename_device,
             commands::validate_config,
             commands::set_rgb_config,
             commands::set_rgb_enabled,

--- a/apps/gui/src/state.rs
+++ b/apps/gui/src/state.rs
@@ -2,7 +2,7 @@ use std::sync::mpsc;
 
 use corsair_common::config::{AppConfig, RgbConfig};
 
-use crate::dto::{DeviceTree, SystemSnapshot};
+use crate::dto::{DeviceTree, ManualDutyResult, SystemSnapshot};
 
 /// Commands sent from Tauri async command handlers to the hardware thread.
 pub enum HwCommand {
@@ -23,10 +23,30 @@ pub enum HwCommand {
         preset: String,
         reply: tokio::sync::oneshot::Sender<Result<(), String>>,
     },
+    /// Legacy V1 duty path — kept for one release for the unmigrated
+    /// Svelte frontend. PR3 migrates callers to
+    /// [`HwCommand::SetManualDutyByDeviceId`].
     SetManualDuty {
         hub_serial: String,
         channels: Vec<u8>,
         duty: u8,
+        reply: tokio::sync::oneshot::Sender<Result<(), String>>,
+    },
+    /// V2 duty path: caller supplies device_ids, the hardware thread
+    /// resolves each to `(hub_serial, channel)` via the live registry,
+    /// buckets per hub, and issues one `set_speeds` per hub. The reply
+    /// reports which ids were applied and which were unresolvable so the
+    /// UI can surface orphans to the user without hiding the failure.
+    SetManualDutyByDeviceId {
+        device_ids: Vec<String>,
+        duty: u8,
+        reply: tokio::sync::oneshot::Sender<Result<ManualDutyResult, String>>,
+    },
+    /// Persist a friendly name for a specific device_id. Empty `name`
+    /// clears the entry (reverts to the system-generated display name).
+    RenameDevice {
+        device_id: String,
+        name: String,
         reply: tokio::sync::oneshot::Sender<Result<(), String>>,
     },
     SetRgbConfig {

--- a/crates/fancontrol/src/control_loop.rs
+++ b/crates/fancontrol/src/control_loop.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -79,20 +79,6 @@ pub struct GroupDutyReport {
     pub channels: Vec<(u8, u8)>, // (channel, duty_u8)
 }
 
-/// RGB frame data for sending to hardware (no dependency on corsair-rgb crate).
-///
-/// Dual-key during the V1→V2 transition: either `device_id` is populated
-/// (V2 path — resolves through the registry) OR `hub_serial` + `channel`
-/// are populated (V1 path — sent directly). When `device_id` is non-empty
-/// it takes precedence. `send_rgb_frames` treats an orphan device_id
-/// (not currently enumerated) as skipped cleanly.
-pub struct RgbFrameRef<'a> {
-    pub hub_serial: &'a str,
-    pub channel: u8,
-    pub device_id: &'a str,
-    pub leds: &'a [[u8; 3]],
-}
-
 pub struct ControlLoop {
     config: AppConfig,
     sensors: HashMap<String, Box<dyn TemperatureSource>>,
@@ -105,6 +91,15 @@ pub struct ControlLoop {
     /// with non-empty `device_ids` resolves through the registry;
     /// otherwise the legacy channel path runs.
     registry: DeviceRegistry,
+    /// Orphan device_ids already warned about this process lifetime. Step 5
+    /// invariant: `send_rgb_frames` receives frames keyed by device_id only;
+    /// a device_id not in the registry means the config references a device
+    /// that isn't enumerated this boot (unplugged, moved elsewhere). We log
+    /// once per boot per device_id — repeating every tick at 30 FPS would
+    /// flood the log. The set is cleared on `update_config` and on
+    /// `replace_hub` so a device that reappears gets a fresh warning budget
+    /// if it disappears again later.
+    logged_orphan_rgb_ids: HashSet<String>,
     shutdown: Arc<AtomicBool>,
 }
 
@@ -459,6 +454,7 @@ impl ControlLoop {
             hubs,
             groups,
             registry,
+            logged_orphan_rgb_ids: HashSet::new(),
             shutdown,
         })
     }
@@ -675,6 +671,15 @@ impl ControlLoop {
         &self.config
     }
 
+    /// Current device identity registry. Used by callers that need to
+    /// resolve (hub_serial, channel) → device_id at config-expansion time
+    /// (notably `apply_rgb_config` in the GUI, which pairs V1
+    /// `RgbDeviceRef` entries with their stable device_id before handing
+    /// zone configs to the renderer).
+    pub fn registry(&self) -> &DeviceRegistry {
+        &self.registry
+    }
+
     /// Names of sensors that are currently initialized and available.
     pub fn available_sensors(&self) -> Vec<String> {
         self.sensors.keys().cloned().collect()
@@ -704,6 +709,11 @@ impl ControlLoop {
         }
         self.config = config;
         self.groups = groups;
+        // A new config may reference a different set of device_ids —
+        // reset the orphan warning dedupe so legitimate new orphans get
+        // surfaced in the log rather than silently suppressed by stale
+        // entries from the previous config.
+        self.logged_orphan_rgb_ids.clear();
         Ok(())
     }
 
@@ -824,6 +834,11 @@ impl ControlLoop {
         // re-enumeration (fans added/removed/reordered on the chain).
         // Rebuild so subsequent cycles resolve device_ids correctly.
         self.registry = build_registry(&self.hubs);
+        // Drop the orphan warning dedupe so a device that disappears
+        // again after a recovery cycle gets a fresh log entry — the
+        // user deserves to know when a reconnected device later goes
+        // missing again, even if we saw it orphan earlier.
+        self.logged_orphan_rgb_ids.clear();
     }
 
     /// Mark that a recovery attempt was made (even if it failed) to enforce
@@ -921,44 +936,74 @@ impl ControlLoop {
     /// device's actual LED count. We must match those counts exactly, or subsequent
     /// devices receive misaligned data.
     ///
-    /// This method uses the hub's cached device enumeration to build a correctly-sized
-    /// buffer for each hub: truncating/padding frame data to match the actual LED count,
-    /// and inserting black for devices without frames.
-    pub fn send_rgb_frames(&mut self, frames: &[RgbFrameRef]) -> usize {
+    /// ## Input shape: `&[(device_id, leds)]`
+    ///
+    /// Post-Step-5 (PR2): the caller supplies frames keyed by stable
+    /// `device_id` only. The renderer produces these; the legacy
+    /// `(hub_serial, channel)` path is gone. This function resolves each
+    /// device_id via the runtime registry, bucketizes by hub, sorts by
+    /// ascending channel within each hub (wire requirement — the hub's
+    /// daisy-chain parser walks the buffer in channel order), and builds a
+    /// flat buffer for every enumerated device on the hub. Devices present
+    /// on a hub but not referenced in `frames` get black fill. Orphan
+    /// device_ids (in the input but not in the registry — e.g. a fan
+    /// unplugged since config load) are logged once per boot per device_id
+    /// and skipped.
+    ///
+    /// ## LED count precedence (Step 6)
+    ///
+    /// For each device we need the actual LED count so the flat buffer
+    /// matches what the hub parser expects. Precedence:
+    ///   1. V2 per-device override: `config.led_count_override_by_id(device_id)`.
+    ///   2. V1 (hub, channel) override: `config.led_count_override(hub, ch)`.
+    ///   3. Hub firmware 0x1d table: `hub_info.led_counts`.
+    ///   4. Device-type default: `dev.device_type.led_count()`.
+    /// V2 and V1 overrides are both pre-applied into `hub_info.led_counts`
+    /// at build time, so in practice the 0x1d-table lookup already reflects
+    /// them. The explicit checks here guard against timing windows where
+    /// `update_config` hasn't refreshed the hub table yet (e.g. a live
+    /// config edit that changes an override — the control loop's next RGB
+    /// tick still produces a correct buffer before the config-apply path
+    /// rewrites `hub_info.led_counts`).
+    pub fn send_rgb_frames(&mut self, frames: &[(String, &[[u8; 3]])]) -> usize {
         use std::collections::BTreeMap;
 
         const BLACK: [u8; 3] = [0, 0, 0];
 
         // Group frames by hub serial, sort by channel within each hub.
         //
-        // Dual-key during the V1→V2 transition: when a frame has a non-
-        // empty device_id, resolve via the registry. Otherwise use the
-        // frame's literal (hub_serial, channel). Orphans (device_ids not
-        // currently enumerated) are skipped silently.
+        // Orphan device_ids (not in the registry) are logged once per boot
+        // per id via `logged_orphan_rgb_ids`, then skipped. A 30 FPS RGB
+        // loop would flood the log otherwise. The dedupe set is reset
+        // when `update_config` or `replace_hub` refreshes the registry.
         //
-        // Ownership note: we key `by_hub` on String (not &str) because
-        // the resolved hub_serial is owned by the registry, and the
-        // registry outlives this function, but not with a borrow that
-        // can be threaded all the way through the HashMap build. Cheap
-        // clones here; RGB frame rate is 30 FPS.
-        let mut by_hub: HashMap<String, BTreeMap<u8, &[[u8; 3]]>> = HashMap::new();
-        for frame in frames {
-            if !frame.device_id.is_empty() {
-                // V2 path: resolve device_id → (hub_serial, channel).
-                let Some(loc) = self.registry.resolve(frame.device_id) else {
-                    // Orphan — skip.
-                    continue;
-                };
-                by_hub
-                    .entry(loc.hub_serial.clone())
-                    .or_default()
-                    .insert(loc.channel, frame.leds);
-            } else {
-                by_hub
-                    .entry(frame.hub_serial.to_string())
-                    .or_default()
-                    .insert(frame.channel, frame.leds);
-            }
+        // We store `(channel, device_id, leds)` keyed by hub so the
+        // per-device LED-count lookup below has the device_id on hand for
+        // the V2 override precedence check.
+        let mut by_hub: HashMap<String, BTreeMap<u8, (String, &[[u8; 3]])>> = HashMap::new();
+        let mut new_orphans: Vec<String> = Vec::new();
+        for (device_id, leds) in frames {
+            let Some(loc) = self.registry.resolve(device_id) else {
+                // Orphan — defer the log until after the loop so we can
+                // update the seen-set without fighting the immutable
+                // borrow on `self.registry` above.
+                if !self.logged_orphan_rgb_ids.contains(device_id) {
+                    new_orphans.push(device_id.clone());
+                }
+                continue;
+            };
+            by_hub
+                .entry(loc.hub_serial.clone())
+                .or_default()
+                .insert(loc.channel, (device_id.clone(), *leds));
+        }
+        for id in new_orphans {
+            warn!(
+                device_id = id.as_str(),
+                "RGB frame references device_id not currently enumerated — \
+                 skipping (further occurrences of this id will be silent this boot)"
+            );
+            self.logged_orphan_rgb_ids.insert(id);
         }
 
         let mut sent = 0;
@@ -991,7 +1036,7 @@ impl ControlLoop {
                     continue; // truly no LEDs
                 }
 
-                let frame_data = frame_channels.get(&dev.channel);
+                let frame_data = frame_channels.get(&dev.channel).map(|(_id, leds)| *leds);
 
                 let leds = if let Some(data) = frame_data {
                     // Truncate or pad to actual LED count
@@ -1615,6 +1660,7 @@ impl ControlLoop {
             hubs: hub_conns,
             groups,
             registry,
+            logged_orphan_rgb_ids: HashSet::new(),
             shutdown: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -2025,22 +2071,35 @@ mod tests {
 
     // --- Step 4: dual-key control loop tests ---
 
-    /// Mock hub that records every set_speeds call so we can verify which
-    /// (channel, duty) pairs were actually dispatched through the
-    /// dual-key path. set_rgb/enter_hardware_mode unused here.
+    /// Mock hub that records every set_speeds and set_rgb call so tests
+    /// can verify which (channel, duty) pairs and (channel, led_count)
+    /// buffers were actually dispatched through the dual-key path.
     struct RecordingHub {
         speeds_sent: std::sync::Mutex<Vec<Vec<(u8, u8)>>>,
+        /// Each element is one `set_rgb` call; per call we record
+        /// `(channel, led_count)` so tests can assert routing and
+        /// buffer sizing without holding the raw byte slices alive.
+        rgb_sent: std::sync::Mutex<Vec<Vec<(u8, usize)>>>,
     }
 
     impl RecordingHub {
         fn new() -> Self {
             Self {
                 speeds_sent: std::sync::Mutex::new(Vec::new()),
+                rgb_sent: std::sync::Mutex::new(Vec::new()),
             }
         }
 
         fn last_speeds(&self) -> Option<Vec<(u8, u8)>> {
             self.speeds_sent.lock().unwrap().last().cloned()
+        }
+
+        fn last_rgb(&self) -> Option<Vec<(u8, usize)>> {
+            self.rgb_sent.lock().unwrap().last().cloned()
+        }
+
+        fn rgb_call_count(&self) -> usize {
+            self.rgb_sent.lock().unwrap().len()
         }
     }
 
@@ -2052,7 +2111,12 @@ mod tests {
         fn get_speeds(&self) -> Result<Vec<FanSpeed>> {
             Ok(Vec::new())
         }
-        fn set_rgb(&self, _channel_leds: &[(u8, &[[u8; 3]])]) -> Result<()> {
+        fn set_rgb(&self, channel_leds: &[(u8, &[[u8; 3]])]) -> Result<()> {
+            let summary: Vec<(u8, usize)> = channel_leds
+                .iter()
+                .map(|(ch, leds)| (*ch, leds.len()))
+                .collect();
+            self.rgb_sent.lock().unwrap().push(summary);
             Ok(())
         }
         fn enter_hardware_mode(&self) -> Result<()> {
@@ -2191,6 +2255,145 @@ mod tests {
             sorted,
             vec![(7u8, 40u8), (8u8, 40u8)],
             "V1 group should keep its literal channels"
+        );
+    }
+
+    // --- Step 5: RGB pipeline keyed by device_id ---
+
+    /// send_rgb_frames now takes `(device_id, leds)` pairs. Each device_id
+    /// must resolve via the registry to its current (hub, channel). Two
+    /// devices on different hubs demonstrate that bucketing routes the
+    /// right LEDs to the right hub.
+    #[test]
+    fn send_rgb_frames_routes_v2_device_ids_correctly() {
+        let hub_a = "HUB_A".to_string();
+        let hub_b = "HUB_B".to_string();
+        let mock_a: Arc<RecordingHub> = Arc::new(RecordingHub::new());
+        let mock_b: Arc<RecordingHub> = Arc::new(RecordingHub::new());
+
+        let mut hubs: HashMap<String, (Arc<dyn IcueLinkTransport>, Vec<u8>)> = HashMap::new();
+        hubs.insert(
+            hub_a.clone(),
+            (mock_a.clone() as Arc<dyn IcueLinkTransport>, Vec::new()),
+        );
+        hubs.insert(
+            hub_b.clone(),
+            (mock_b.clone() as Arc<dyn IcueLinkTransport>, Vec::new()),
+        );
+
+        // ID_A1 on HUB_A ch 1; ID_B2 on HUB_B ch 2. QxFan device type
+        // declares 34 LEDs as its default.
+        let mut devices_by_hub: HashMap<String, Vec<corsair_hid::LinkDevice>> = HashMap::new();
+        devices_by_hub.insert(
+            hub_a.clone(),
+            vec![mk_link_device(1, "ID_A1")],
+        );
+        devices_by_hub.insert(
+            hub_b.clone(),
+            vec![mk_link_device(2, "ID_B2")],
+        );
+
+        let mut cl = ControlLoop::from_parts_for_test_with_devices(
+            base_v1_config(),
+            hubs,
+            devices_by_hub,
+            Vec::new(),
+            HashMap::new(),
+        );
+
+        // Build frames keyed by device_id. Each device advertises 34 LEDs
+        // (QxFan default), so provide that many.
+        let a_leds = vec![[1u8, 2, 3]; 34];
+        let b_leds = vec![[4u8, 5, 6]; 34];
+        let frames: Vec<(String, &[[u8; 3]])> = vec![
+            ("ID_A1".to_string(), a_leds.as_slice()),
+            ("ID_B2".to_string(), b_leds.as_slice()),
+        ];
+
+        let sent = cl.send_rgb_frames(&frames);
+
+        // Each hub's enumeration lists one device; the flat buffer for
+        // each hub is therefore one entry long.
+        assert_eq!(sent, 2, "one device per hub should yield sent == 2");
+
+        // HUB_A call should include channel 1 with 34 LEDs (not channel 2).
+        let a_call = mock_a.last_rgb().expect("HUB_A should have received set_rgb");
+        assert_eq!(
+            a_call,
+            vec![(1u8, 34usize)],
+            "HUB_A should receive ch1 34 LEDs (ID_A1)"
+        );
+        let b_call = mock_b.last_rgb().expect("HUB_B should have received set_rgb");
+        assert_eq!(
+            b_call,
+            vec![(2u8, 34usize)],
+            "HUB_B should receive ch2 34 LEDs (ID_B2)"
+        );
+    }
+
+    /// Orphan device_ids (in frames but not in registry) are skipped cleanly
+    /// and logged only once per boot per id. We verify the behavior by
+    /// calling send_rgb_frames twice with the same orphan id — the second
+    /// call must still skip without crashing and without redundant log
+    /// attempts (the `logged_orphan_rgb_ids` set dedupes the warning path).
+    #[test]
+    fn send_rgb_frames_skips_orphan_device_id_with_log() {
+        let hub_a = "HUB_A".to_string();
+        let mock_a: Arc<RecordingHub> = Arc::new(RecordingHub::new());
+
+        let mut hubs: HashMap<String, (Arc<dyn IcueLinkTransport>, Vec<u8>)> = HashMap::new();
+        hubs.insert(
+            hub_a.clone(),
+            (mock_a.clone() as Arc<dyn IcueLinkTransport>, Vec::new()),
+        );
+
+        // Only ID_A1 is enumerated; ID_ORPHAN is never seen.
+        let mut devices_by_hub: HashMap<String, Vec<corsair_hid::LinkDevice>> = HashMap::new();
+        devices_by_hub.insert(hub_a.clone(), vec![mk_link_device(1, "ID_A1")]);
+
+        let mut cl = ControlLoop::from_parts_for_test_with_devices(
+            base_v1_config(),
+            hubs,
+            devices_by_hub,
+            Vec::new(),
+            HashMap::new(),
+        );
+
+        let real_leds = vec![[10u8, 20, 30]; 34];
+        let orphan_leds = vec![[99u8, 99, 99]; 34];
+        let frames: Vec<(String, &[[u8; 3]])> = vec![
+            ("ID_A1".to_string(), real_leds.as_slice()),
+            ("ID_ORPHAN".to_string(), orphan_leds.as_slice()),
+        ];
+
+        // First call — should warn once on the orphan and successfully
+        // route ID_A1 to channel 1.
+        let sent1 = cl.send_rgb_frames(&frames);
+        assert_eq!(
+            sent1, 1,
+            "one real device on hub; orphan skipped so sent == 1"
+        );
+        assert!(
+            cl.logged_orphan_rgb_ids.contains("ID_ORPHAN"),
+            "orphan id should be recorded in the seen-set after first call"
+        );
+        let call1 = mock_a
+            .last_rgb()
+            .expect("HUB_A should have received a set_rgb call");
+        assert_eq!(
+            call1,
+            vec![(1u8, 34usize)],
+            "HUB_A should receive only ch1 (ID_A1), not the orphan"
+        );
+
+        // Second call — orphan is now in the seen-set; skip silently.
+        // The real device still makes it through.
+        let sent2 = cl.send_rgb_frames(&frames);
+        assert_eq!(sent2, 1, "orphan still skipped on repeat");
+        assert_eq!(
+            mock_a.rgb_call_count(),
+            2,
+            "hub should have received two set_rgb calls overall"
         );
     }
 }

--- a/crates/fancontrol/src/control_loop.rs
+++ b/crates/fancontrol/src/control_loop.rs
@@ -1020,16 +1020,40 @@ impl ControlLoop {
             let mut device_leds: Vec<(u8, Vec<[u8; 3]>)> = Vec::new();
 
             for dev in &hub_conn.info.devices {
-                // Use hub firmware's LED count (from 0x1d table) if available,
-                // otherwise fall back to device type default.
-                // The 0x1d table is authoritative for LINK Adapters with connected strips.
-                let actual_count = hub_conn
-                    .info
-                    .led_counts
-                    .get(&dev.channel)
-                    .copied()
+                // LED count precedence (Step 6 — device_id-first):
+                //   1. V2 per-device override: `led_count_override_by_id`
+                //      keyed on the device_id (stable across topology
+                //      shifts — a fan moved to a different port keeps its
+                //      override).
+                //   2. V1 (hub, channel) override: `led_count_override`
+                //      for the current hub/channel pair.
+                //   3. Hub firmware 0x1d table (`info.led_counts`) —
+                //      authoritative for LINK Adapters with connected
+                //      strips.
+                //   4. Device-type default (e.g. QxFan = 34).
+                //
+                // In the steady state (1) and (2) are already folded
+                // into `info.led_counts` by `build()` / `update_config`,
+                // so this chain mostly documents intent. The explicit
+                // check still fires correctly in two real cases:
+                //   - a config update between an RGB tick and the
+                //     control-loop `update_config` call that folds the
+                //     new overrides into led_counts;
+                //   - test fixtures that don't seed `led_counts` but
+                //     want the override to take effect.
+                let actual_count = self
+                    .config
+                    .led_count_override_by_id(&dev.device_id)
+                    .or_else(|| self.config.led_count_override(serial.as_str(), dev.channel))
+                    .or_else(|| {
+                        hub_conn
+                            .info
+                            .led_counts
+                            .get(&dev.channel)
+                            .copied()
+                            .filter(|&c| c > 0)
+                    })
                     .map(|c| c as usize)
-                    .filter(|&c| c > 0)
                     .unwrap_or(dev.device_type.led_count() as usize);
 
                 if actual_count == 0 {
@@ -2394,6 +2418,80 @@ mod tests {
             mock_a.rgb_call_count(),
             2,
             "hub should have received two set_rgb calls overall"
+        );
+    }
+
+    // --- Step 6: LED-count override by device_id ---
+
+    /// V2 per-device-id override takes precedence over V1 (hub, channel)
+    /// override in send_rgb_frames' LED-count resolution. Both overrides
+    /// refer to the same physical device (same hub, same channel). The V2
+    /// override value must win: the flat buffer to the hub should size the
+    /// device at the V2 value.
+    #[test]
+    fn v2_led_count_override_takes_precedence_over_v1() {
+        let hub_serial = "HUB_A".to_string();
+        let mock: Arc<RecordingHub> = Arc::new(RecordingHub::new());
+        let mut hubs: HashMap<String, (Arc<dyn IcueLinkTransport>, Vec<u8>)> = HashMap::new();
+        hubs.insert(
+            hub_serial.clone(),
+            (mock.clone() as Arc<dyn IcueLinkTransport>, Vec::new()),
+        );
+
+        // A QxFan-type device with a 26-hex device_id on ch 1. The type
+        // default is 34 LEDs, but the user has overridden:
+        //   - V1 path: (HUB_A, 1) → 21 (stale/legacy)
+        //   - V2 path: device_id "ID_A1" → 30 (canonical)
+        // V2 must win.
+        let mut devices_by_hub: HashMap<String, Vec<corsair_hid::LinkDevice>> = HashMap::new();
+        devices_by_hub.insert(hub_serial.clone(), vec![mk_link_device(1, "ID_A1")]);
+
+        // Config with BOTH overrides pointing at the same physical device.
+        let config = AppConfig {
+            schema_version: corsair_common::config::SCHEMA_VERSION_V2,
+            general: GeneralConfig {
+                poll_interval_ms: 1000,
+                log_level: "info".to_string(),
+                lhm_exe_path: None,
+            },
+            fan_groups: Vec::new(),
+            rgb: Default::default(),
+            device_overrides: vec![DeviceOverride {
+                hub_serial: hub_serial.clone(),
+                channel: 1,
+                led_count: 21, // V1 — should NOT be used
+            }],
+            devices: vec![corsair_common::config::v2::DeviceEntry {
+                device_id: "ID_A1".to_string(),
+                name: None,
+                led_count: Some(30), // V2 — must win
+            }],
+        };
+
+        let mut cl = ControlLoop::from_parts_for_test_with_devices(
+            config,
+            hubs,
+            devices_by_hub,
+            Vec::new(),
+            HashMap::new(),
+        );
+
+        // Supply a long buffer (34 QxFan defaults); the flat buffer
+        // should be truncated to 30 LEDs per the V2 override.
+        let long_leds = vec![[7u8, 7, 7]; 34];
+        let frames: Vec<(String, &[[u8; 3]])> =
+            vec![("ID_A1".to_string(), long_leds.as_slice())];
+
+        let sent = cl.send_rgb_frames(&frames);
+        assert_eq!(sent, 1);
+
+        let call = mock
+            .last_rgb()
+            .expect("HUB_A should have received set_rgb");
+        assert_eq!(
+            call,
+            vec![(1u8, 30usize)],
+            "V2 per-device override (30) must win over V1 (21) and type default (34)"
         );
     }
 }

--- a/crates/fancontrol/src/lib.rs
+++ b/crates/fancontrol/src/lib.rs
@@ -3,6 +3,6 @@ pub mod control_loop;
 pub mod curve;
 pub mod pid;
 
-pub use control_loop::{ControlLoop, CycleResult, GroupDutyReport, HubHealthReport, RgbFrameRef};
+pub use control_loop::{ControlLoop, CycleResult, GroupDutyReport, HubHealthReport};
 pub use curve::FanCurve;
 pub use pid::PidController;

--- a/crates/rgb/src/frame.rs
+++ b/crates/rgb/src/frame.rs
@@ -2,20 +2,19 @@ use serde::Serialize;
 
 use crate::Rgb;
 
-/// A single frame of LED data for one device channel.
+/// A single frame of LED data for one device.
 ///
-/// During the V1→V2 identity refactor this struct carries BOTH the legacy
-/// (hub_serial, channel) location keys AND the stable `device_id`. The
-/// renderer populates `device_id` when the device picker provided one;
-/// otherwise it stays empty and downstream code falls back to the legacy
-/// path. A later step (PR2 Step 5) drops hub_serial/channel in favor of
-/// device_id-only once all call sites are migrated.
+/// Post-Step-5 (PR2): the frame is keyed by stable `device_id` only. The
+/// renderer no longer emits frames with `(hub_serial, channel)` location
+/// tags — the control loop's `send_rgb_frames` resolves each `device_id` via
+/// the runtime registry immediately before the wire write. If a DeviceTarget
+/// reaches frame construction without a device_id, that is a bug upstream of
+/// the renderer (the registry lookup in `apply_rgb_config` should have
+/// populated it, or skipped the device outright).
 #[derive(Debug, Clone, Serialize)]
 pub struct RgbFrame {
-    pub hub_serial: String,
-    pub channel: u8,
-    /// Stable device identity. Empty string during the transition when the
-    /// zone targets came from a V1 config (hub_serial + channel only).
+    /// Stable device identity (26-hex string burned in at manufacturing).
+    /// Mandatory as of Step 5.
     pub device_id: String,
     pub leds: Vec<Rgb>,
 }

--- a/crates/rgb/src/renderer.rs
+++ b/crates/rgb/src/renderer.rs
@@ -16,6 +16,7 @@ pub struct RgbRenderer {
 }
 
 struct ZoneState {
+    #[allow(dead_code)]
     zone_id: String,
     devices: Vec<DeviceTarget>,
     layer_stack: LayerStack,
@@ -24,15 +25,14 @@ struct ZoneState {
     transition: Option<CrossFade>,
 }
 
+/// Internal renderer target. Post-Step-5 the renderer only knows the stable
+/// `device_id` — who routes the resulting LEDs to which hub/channel is the
+/// control loop's concern (it resolves via `DeviceRegistry` immediately
+/// before the wire write). If a zone references a device that cannot be
+/// resolved to a device_id at `apply_rgb_config` time, the caller must
+/// skip it there; the renderer never carries an unknown target.
 struct DeviceTarget {
-    hub_serial: String,
-    channel: u8,
-    /// Stable device identity. `None` when the target came from a V1 config
-    /// that only knows (hub_serial, channel). Populated at the `apply_rgb_config`
-    /// construction site (in `apps/gui`) by looking up the channel in the
-    /// runtime registry. Stays `None` during transition when the device is
-    /// orphaned (referenced in config but not currently enumerated).
-    device_id: Option<String>,
+    device_id: String,
     layout: LedLayout,
 }
 
@@ -79,8 +79,6 @@ impl RgbRenderer {
                     .devices
                     .iter()
                     .map(|d| DeviceTarget {
-                        hub_serial: d.hub_serial.clone(),
-                        channel: d.channel,
                         device_id: d.device_id.clone(),
                         layout: d.layout.clone(),
                     })
@@ -142,10 +140,21 @@ impl RgbRenderer {
                     }
                 }
 
+                // Post-Step-5: the renderer emits frames keyed by
+                // stable device_id. `apply_rgb_config` in `apps/gui` is
+                // responsible for only constructing DeviceConfig entries
+                // with a populated device_id — an empty string here is
+                // upstream-bug territory, caught by the `expect` to
+                // surface the violation immediately instead of silently
+                // emitting orphan frames.
+                assert!(
+                    !device.device_id.is_empty(),
+                    "DeviceTarget must have device_id by Step 5 — upstream apply_rgb_config \
+                     failed to resolve or skip this device"
+                );
+
                 frames.push(RgbFrame {
-                    hub_serial: device.hub_serial.clone(),
-                    channel: device.channel,
-                    device_id: device.device_id.clone().unwrap_or_default(),
+                    device_id: device.device_id.clone(),
                     leds,
                 });
             }
@@ -173,12 +182,11 @@ pub struct ZoneConfig {
     pub flow: Option<FlowConfig>,
 }
 
+/// Per-device renderer input. Stable `device_id` is mandatory — callers that
+/// cannot resolve a zone's device reference to a device_id must skip it at
+/// the config-expansion site (see `apply_rgb_config` in `apps/gui`).
 pub struct DeviceConfig {
-    pub hub_serial: String,
-    pub channel: u8,
-    /// Stable device identity when known. `None` during V1→V2 transition
-    /// when the source config only had (hub_serial, channel).
-    pub device_id: Option<String>,
+    pub device_id: String,
     pub layout: LedLayout,
 }
 
@@ -188,16 +196,17 @@ mod tests {
     use crate::color::BlendMode;
     use crate::effect::EffectConfig;
 
+    /// Renderer produces frames keyed by `device_id` (Step 5 invariant).
+    /// The previous `hub_serial`/`channel` fields are gone — the renderer
+    /// no longer cares about wire location.
     #[test]
-    fn renderer_produces_frames() {
+    fn renderer_produces_frames_with_device_id() {
         let mut renderer = RgbRenderer::new();
         renderer.update_config(
             &[ZoneConfig {
                 name: "test".into(),
                 devices: vec![DeviceConfig {
-                    hub_serial: "HUB1".into(),
-                    channel: 1,
-                    device_id: None,
+                    device_id: "0100AAA".into(),
                     layout: LedLayout::qx_fan(),
                 }],
                 layers: vec![Layer {
@@ -217,8 +226,7 @@ mod tests {
         let ctx = EffectContext::default();
         let frames = renderer.tick(&ctx);
         assert_eq!(frames.len(), 1);
-        assert_eq!(frames[0].hub_serial, "HUB1");
-        assert_eq!(frames[0].channel, 1);
+        assert_eq!(frames[0].device_id, "0100AAA");
         assert_eq!(frames[0].leds.len(), 34);
         assert_eq!(frames[0].leds[0], Rgb::new(255, 0, 0));
     }
@@ -230,9 +238,7 @@ mod tests {
             &[ZoneConfig {
                 name: "test".into(),
                 devices: vec![DeviceConfig {
-                    hub_serial: "HUB1".into(),
-                    channel: 1,
-                    device_id: None,
+                    device_id: "0100AAA".into(),
                     layout: LedLayout::FanRing { led_count: 4 },
                 }],
                 layers: vec![Layer {
@@ -264,15 +270,11 @@ mod tests {
                     name: "zone1".into(),
                     devices: vec![
                         DeviceConfig {
-                            hub_serial: "HUB1".into(),
-                            channel: 1,
-                            device_id: None,
+                            device_id: "0100AAA".into(),
                             layout: LedLayout::FanRing { led_count: 4 },
                         },
                         DeviceConfig {
-                            hub_serial: "HUB1".into(),
-                            channel: 2,
-                            device_id: None,
+                            device_id: "0100BBB".into(),
                             layout: LedLayout::FanRing { led_count: 4 },
                         },
                     ],
@@ -290,9 +292,7 @@ mod tests {
                 ZoneConfig {
                     name: "zone2".into(),
                     devices: vec![DeviceConfig {
-                        hub_serial: "HUB2".into(),
-                        channel: 1,
-                        device_id: None,
+                        device_id: "0100CCC".into(),
                         layout: LedLayout::ls350(),
                     }],
                     layers: vec![Layer {


### PR DESCRIPTION
## Summary

PR2 of 3 — runtime paths now speak device_id end-to-end. RGB rendering is device_id-first, per-device LED-count overrides resolve by device_id, and two new Tauri commands let the frontend (PR3) drive duty by device_id and rename devices. Still **no user-visible behavior change** for V1 configs: everything falls back cleanly when device_ids aren't populated.

**Stacked on #8 (PR1).** GitHub will auto-retarget this to main when PR1 merges.

## Commits

| SHA | Step | Subject |
|-----|------|---------|
| `83b2988` | 5 | `refactor(fancontrol,rgb): RGB pipeline keyed by device_id` |
| `4d8bd9a` | 6 | `feat(config): per-device LED-count overrides by device_id` |
| `53c2c69` | 7 | `feat(gui): device_id-based Tauri commands + device renaming` |

## What's in

### Step 5 — RGB pipeline device_id-first (`83b2988`)
- `RgbFrame` drops `hub_serial` + `channel`; `device_id: String` is the only identity.
- `DeviceTarget` (renderer-side) the same — renderer stops caring about hubs and channels.
- `apply_rgb_config` resolves V2 device_ids directly; resolves V1 `(hub, channel)` via `DeviceRegistry`; warns-and-skips orphans both ways.
- `send_rgb_frames` signature: `&[(String, &[[u8; 3]])]`. `RgbFrameRef` deleted (single caller, single implementer — tuple is cleaner than maintaining a struct).
- Orphan device_ids logged **once per boot per id** via a `HashSet` on `ControlLoop`. Dedup set clears on `update_config` and `replace_hub` so user gets a fresh warning after relevant changes.
- `RgbFrameDto` still dual-carries `hub_serial`/`channel`/`device_id` for the current frontend preview — PR3 drops the legacy fields after the Svelte preview migrates.

### Step 6 — LED-count override by device_id (`4d8bd9a`)
- `send_rgb_frames` precedence chain (highest → lowest): **V2 `led_count_override_by_id` → V1 `led_count_override(hub, channel)` → hub 0x1d table → device-type default**. Documented in a code comment at the call site.

### Step 7 — Tauri commands + rename (`53c2c69`)
- **`set_manual_duty_by_device_id(device_ids: Vec<String>, duty: u8) -> Result<ManualDutyResult, String>`** — resolves each id via registry, buckets by hub, calls per-hub `set_speeds`. Returns `{ applied: Vec<String>, unresolved: Vec<String> }` so the frontend can surface partial results.
- **`rename_device(device_id: String, name: String) -> Result<(), String>`** — upserts into `AppConfig.devices` (the V2 `Vec<v2::DeviceEntry>`). Empty name removes the entry. Atomic config write via the existing flow. **Does NOT bump `schema_version`** (rename is orthogonal to schema version; explicit TOML round-trip test covers this).
- Legacy `set_manual_duty(hub_serial, channels, duty)` marked `#[deprecated]` but kept wired for PR3's frontend migration window.

## Plan adaptations

1. **`RgbFrameRef` removed entirely** instead of "kept with device_id mandatory". Only one caller, one implementer — the tuple is cleaner.
2. **`rename_device` emits 5 unit tests** (plan said 1 would suffice). The schema-version-preservation contract is load-bearing; explicit TOML round-trip test asserts it.
3. **Orphan dedup set clears on config-update and hub-replace.** Not speced in the plan, but clearly correct — users need to know when a thing goes offline *again* after coming back.
4. **`DeviceTarget.zone_id`** got a `#[allow(dead_code)]` — still useful for debug logging but unread today. Removing it is out of PR2 scope.

## Tests

- **PR1 baseline**: 116
- **PR2 HEAD**: **124** (+8)

Per-crate at HEAD:
- `corsair-common`: 24
- `corsair-fancontrol`: 31 (was 28; +3: `v2_led_count_override_takes_precedence_over_v1`, `send_rgb_frames_routes_v2_device_ids_correctly`, `send_rgb_frames_skips_orphan_device_id_with_log`)
- `corsair-hid`: 35
- `corsair-rgb`: 25 (renamed `renderer_produces_frames` → `renderer_produces_frames_with_device_id`)
- `corsair-hub-gui`: 5 (was 0 — new rename unit tests)
- `corsair-sensors`: 4

```
cargo test --workspace    # 124 passing
cargo build --workspace   # clean
```

## Orphan / edge cases documented

- **Config-update during an RGB tick**: precedence chain is resilient to the timing window where a user edits `devices[].led_count` and the RGB tick fires before `update_config` folds it into hub state.
- **`rename_device` on V1 config writes a V2 field without schema_version bump** — V1 configs accept V2 fields as `#[serde(default)]`. Covered by `rename_device_roundtrips_through_toml_on_v1_config`.
- **`ManualDutyResult.applied` on partial failure**: per-hub call is atomic; cross-hub call is not. The outer `Err` path does not guarantee rollback. Frontend caller in PR3 should surface this behavior explicitly.

## Follow-ups for PR3 (UX)

1. Svelte frontend still calls deprecated `set_manual_duty` — migrate to `set_manual_duty_by_device_id`.
2. `RgbFrameDto` still carries `hub_serial` + `channel` for preview compatibility — drop after frontend keys on device_id.
3. `FanReading.hub_serial` + `channel` same pattern — frontend migration first, DTO cleanup after.
4. Inline device pickers (fan groups, RGB zones) per plan Step 9.
5. Rename UI wiring per plan Step 9.
6. Migration invocation at startup per plan Step 10.

## Risk & rollback

All 3 commits independently revertable. V1 configs continue to work unchanged. The only runtime-visible change for V1 users is the orphan-dedup log lines — new informational warnings, no behavior shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)